### PR TITLE
Fix homepage keynote background image. Ticket #28

### DIFF
--- a/static/_sass/partials/_content.scss
+++ b/static/_sass/partials/_content.scss
@@ -1,5 +1,6 @@
 .page-main {
   background: url("../images/top-content-bg.jpg") top center no-repeat;
+  background-size: cover;
 }
 
 .region.top-content {


### PR DESCRIPTION
**Issue:** #28 

## Sample output
**Wide**
<img width="1337" alt="screen shot 2017-10-23 at 10 29 26 am" src="https://user-images.githubusercontent.com/3686017/31869839-30d20380-b7dd-11e7-859a-87cff9f32af2.png">

**Normal**
<img width="1214" alt="screen shot 2017-10-23 at 10 29 58 am" src="https://user-images.githubusercontent.com/3686017/31869840-3242e3a6-b7dd-11e7-9d3b-a767133ad642.png">

**Mobile**
<img width="679" alt="screen shot 2017-10-23 at 10 30 13 am" src="https://user-images.githubusercontent.com/3686017/31869841-337c8aec-b7dd-11e7-93b3-f3f2197a2cc0.png">
